### PR TITLE
Switch query string default operator from OR to AND

### DIFF
--- a/nde-web/pipeline.py
+++ b/nde-web/pipeline.py
@@ -33,7 +33,7 @@ class NDEQueryBuilder(ESQueryBuilder):
                 # term query
                 Q('term', _id={"value": q, "boost": 5}),
                 # query string
-                Q('query_string', query=q, lenient=True)
+                Q('query_string', query=q, default_operator="AND", lenient=True)
             ]
 
             search = search.query('dis_max', queries=queries)


### PR DESCRIPTION
@jal347 It looks like this should switch the default operator for a simple query to be AND instead of OR, so `q=influenza vaccine` is interpreted as `q=influenza AND vaccine` instead of `q=influenza OR vaccine` ([current behavior](https://api.data.niaid.nih.gov/v1/query?q=influenza%20vaccine)). Thanks!