### PR TITLE
User Accounts

### DIFF
--- a/nde-web/config_web.py
+++ b/nde-web/config_web.py
@@ -1,22 +1,60 @@
 import copy
 
+from authn.authn_provider import UserCookieAuthProvider
 from biothings.web.settings.default import APP_LIST, QUERY_KWARGS
+from handlers import (
+    GitHubLoginHandler,
+    LogoutHandler,
+    NDESourceHandler,
+    ORCIDLoginHandler,
+    UserInfoHandler,
+    WebAppHandler,
+)
+from user_data import (
+    UserDataHandler,
+    UserFavoriteDatasetsHandler,
+    UserFavoriteSearchesHandler,
+)
+from xsrf import XSRFToken
 
 ES_INDICES = {
     # 'zenodo': 'zenodo_current',
     # 'immport': 'immport_current'
-    None: "nde_all_current"
+    None: "nde_all_current",
     # 'zenodo': 'zenodo_20221020_6h4aac2v'
     # 'acd': 'acd_niaid_20221109_o6tbj5ct'
 }
 
+# Elasticsearch index for persistent user profiles and preferences
+ES_USER_INDEX = "nde_user_profiles"
 APP_LIST += [
-    (r"/{ver}/metadata/?", "handlers.NDESourceHandler"),
+    (r"/{ver}/metadata/?", NDESourceHandler),
 ]
+
+# OAuth and XSRF handlers
+APP_LIST += [
+    (r"/user_info", UserInfoHandler),
+    (r"/logout", LogoutHandler),
+    (r"/login/github", GitHubLoginHandler),
+    (r"/login/orcid", ORCIDLoginHandler),
+    (r"/xsrf_token", XSRFToken),
+]
+
+# User data persistence handlers
+APP_LIST += [
+    (r"/user/data", UserDataHandler),
+    (r"/user/data/favorites/searches", UserFavoriteSearchesHandler),
+    (r"/user/data/favorites/datasets", UserFavoriteDatasetsHandler),
+]
+
+# Authentication provider chain for BioThingsAuthnMixin consumers
+AUTHN_PROVIDERS = (
+    (UserCookieAuthProvider, {}),
+)
 
 # replace default landing page handler
 assert APP_LIST[0][0] == "/"
-APP_LIST[0] = ("/", "handlers.WebAppHandler")
+APP_LIST[0] = ("/", WebAppHandler)
 
 
 # *****************************************************************************
@@ -35,7 +73,6 @@ SOURCE_TYPEDEF = {
     "lineage": {"type": int, "default": None},
     "use_ai_search": {"type": bool, "default": False},
 }
-
 
 QUERY_KWARGS = copy.deepcopy(QUERY_KWARGS)
 QUERY_KWARGS["GET"].update(SOURCE_TYPEDEF)

--- a/nde-web/saved_search_counts.py
+++ b/nde-web/saved_search_counts.py
@@ -1,0 +1,271 @@
+"""Build count queries for user saved searches.
+
+The user profile index stores saved searches as plain JSON objects.  These
+helpers keep the stored ``total`` calculation aligned with the public search
+query shape without depending on Tornado or BioThings runtime objects.
+"""
+
+from collections.abc import Iterable, Mapping
+from datetime import datetime, timezone
+
+
+DEFAULT_DATA_INDEX = "nde_all_current"
+DEFAULT_USER_INDEX = "nde_user_profiles"
+
+_BROWSE_ALL_QUERIES = frozenset({"", "__all__", "__any__", "*", "*:*"})
+_SUPPORTED_TYPES = ["Dataset", "ResourceCatalog", "Sample", "DataCollection"]
+_DEFAULT_DATE_START = "2000-01-01"
+
+def build_saved_search_count_body(
+    query: str | None,
+    filters=None,
+    *,
+    include_frontend_defaults: bool = True,
+) -> dict:
+    """Return an Elasticsearch count body for a saved search entry."""
+    extra_filter = build_saved_search_extra_filter(
+        filters,
+        include_frontend_defaults=include_frontend_defaults,
+    )
+    bool_query = {
+        "must": [_build_query_clause(query)],
+        "filter": [_build_type_filter(), *_build_filter_clauses(extra_filter)],
+    }
+    return {"query": {"bool": bool_query}}
+
+
+def build_saved_search_extra_filter(
+    filters=None,
+    *,
+    include_frontend_defaults: bool = True,
+    year: int | None = None,
+) -> str | None:
+    """Return the frontend-equivalent extra_filter for a saved search."""
+    clauses = []
+    user_filter = _filters_to_query_string(filters)
+
+    if include_frontend_defaults:
+        default_filter = frontend_default_extra_filter(year=year)
+        if not _looks_like_frontend_default_filter(user_filter):
+            clauses.append(default_filter)
+
+    if user_filter:
+        clauses.append(user_filter)
+
+    return " AND ".join(f"({clause})" for clause in clauses) or None
+
+
+def frontend_default_extra_filter(*, year: int | None = None) -> str:
+    """Default frontend visibility filter applied to ordinary search totals."""
+    year = year or datetime.now(timezone.utc).year
+    return (
+        f'(date:["{_DEFAULT_DATE_START}" TO "{year}-12-31"] '
+        'OR (-_exists_:("date"))) '
+        'AND NOT(@type:Sample AND NOT additionalType:"BioSample")'
+    )
+
+
+def _build_type_filter() -> dict:
+    computational_tool_condition = {
+        "bool": {
+            "must": [
+                {"term": {"@type": "ComputationalTool"}},
+                {"term": {"includedInDataCatalog.name": "bio.tools"}},
+            ]
+        }
+    }
+    return {
+        "bool": {
+            "should": [
+                {"terms": {"@type": _SUPPORTED_TYPES}},
+                computational_tool_condition,
+            ],
+            "minimum_should_match": 1,
+        }
+    }
+
+
+def _build_query_clause(query: str | None) -> dict:
+    q = str(query or "").strip()
+    if q in _BROWSE_ALL_QUERIES:
+        return {"match_all": {}}
+
+    # Mirrors pipeline.NDEQueryBuilder.default_string_query, minus scoring
+    # wrappers that do not affect count results.
+    if ":" in q or " AND " in q or " OR " in q:
+        return {
+            "query_string": {
+                "query": q,
+                "default_operator": "AND",
+                "lenient": True,
+            }
+        }
+
+    if q.startswith('"') and q.endswith('"'):
+        unquoted = q.strip('"')
+        return {
+            "dis_max": {
+                "queries": [
+                    {"term": {"_id": {"value": unquoted, "boost": 5}}},
+                    {"term": {"name": {"value": unquoted, "boost": 5}}},
+                    {
+                        "query_string": {
+                            "query": q,
+                            "default_operator": "AND",
+                            "lenient": True,
+                        }
+                    },
+                ]
+            }
+        }
+
+    queries = [
+        {"term": {"_id": {"value": q, "boost": 5}}},
+        {"term": {"name": {"value": q, "boost": 5}}},
+        {
+            "query_string": {
+                "query": q,
+                "default_operator": "AND",
+                "lenient": True,
+            }
+        },
+    ]
+    if "*" not in q and "?" not in q:
+        queries.append(
+            {
+                "query_string": {
+                    "query": "* ".join(q.split()) + "*",
+                    "default_operator": "AND",
+                    "boost": 0.5,
+                    "lenient": True,
+                }
+            }
+        )
+    return {"dis_max": {"queries": queries}}
+
+
+def _build_filter_clauses(extra_filter: str | None) -> list[dict]:
+    if not extra_filter:
+        return []
+
+    return [{"query_string": {"query": extra_filter}}]
+
+
+def _filters_to_query_string(filters) -> str | None:
+    if filters in (None, "", False):
+        return None
+
+    if isinstance(filters, str):
+        return filters.strip() or None
+
+    if isinstance(filters, Mapping):
+        return _mapping_filter_to_query_string(filters)
+
+    if isinstance(filters, Iterable):
+        clauses = [_filters_to_query_string(item) for item in filters]
+        clauses = [clause for clause in clauses if clause]
+        return " AND ".join(f"({clause})" for clause in clauses) or None
+
+    return None
+
+
+def _mapping_filter_to_query_string(filters: Mapping) -> str | None:
+    if not filters:
+        return None
+
+    if "query_string" in filters:
+        query_string = filters.get("query_string") or {}
+        if isinstance(query_string, Mapping):
+            return query_string.get("query")
+
+    if "extra_filter" in filters:
+        return _filters_to_query_string(filters["extra_filter"])
+    if "filter" in filters:
+        return _filters_to_query_string(filters["filter"])
+    if "filters" in filters:
+        return _filters_to_query_string(filters["filters"])
+
+    es_clause = _es_filter_clause_to_query_string(filters)
+    if es_clause:
+        return es_clause
+
+    clauses = []
+    for field, value in filters.items():
+        clause = _field_filter_to_query_string(field, value)
+        if clause:
+            clauses.append(clause)
+    return " AND ".join(clauses) or None
+
+
+def _es_filter_clause_to_query_string(filters: Mapping) -> str | None:
+    if set(filters) == {"term"}:
+        term = filters["term"]
+        if isinstance(term, Mapping) and len(term) == 1:
+            field, value = next(iter(term.items()))
+            if isinstance(value, Mapping) and "value" in value:
+                value = value["value"]
+            return _field_filter_to_query_string(field, value)
+
+    if set(filters) == {"terms"}:
+        terms = filters["terms"]
+        if isinstance(terms, Mapping) and len(terms) == 1:
+            field, values = next(iter(terms.items()))
+            return _field_filter_to_query_string(field, values)
+
+    if set(filters) == {"exists"}:
+        exists = filters["exists"]
+        if isinstance(exists, Mapping) and exists.get("field"):
+            return f'_exists_:{exists["field"]}'
+
+    if set(filters) == {"range"}:
+        ranges = filters["range"]
+        if isinstance(ranges, Mapping) and len(ranges) == 1:
+            field, bounds = next(iter(ranges.items()))
+            if isinstance(bounds, Mapping):
+                lower = bounds.get("gte", bounds.get("gt", "*"))
+                upper = bounds.get("lte", bounds.get("lt", "*"))
+                return (
+                    f"{field}:[{_quote_query_value(lower)} "
+                    f"TO {_quote_query_value(upper)}]"
+                )
+
+    return None
+
+
+def _field_filter_to_query_string(field: str, value) -> str | None:
+    if value in (None, "", False):
+        return None
+
+    if isinstance(value, Mapping):
+        if "values" in value:
+            return _field_filter_to_query_string(field, value["values"])
+        if "value" in value:
+            return _field_filter_to_query_string(field, value["value"])
+        return None
+
+    if isinstance(value, str):
+        return f"{field}:{_quote_query_value(value)}"
+
+    if isinstance(value, Iterable):
+        values = [item for item in value if item not in (None, "", False)]
+        if not values:
+            return None
+        return f"{field}:({' OR '.join(_quote_query_value(item) for item in values)})"
+
+    return f"{field}:{_quote_query_value(value)}"
+
+
+def _quote_query_value(value) -> str:
+    if value == "*":
+        return "*"
+    text = str(value).replace("\\", "\\\\").replace('"', '\\"')
+    return f'"{text}"'
+
+
+def _looks_like_frontend_default_filter(extra_filter: str | None) -> bool:
+    if not extra_filter:
+        return False
+    return (
+        "NOT(@type:Sample AND NOT additionalType" in extra_filter
+        or "NOT+(@type:Sample+AND+NOT+additionalType" in extra_filter
+    )

--- a/nde-web/scripts/README.md
+++ b/nde-web/scripts/README.md
@@ -78,6 +78,26 @@ bootstrap script creates the stub with an empty `schedule` string and empty
 `schema` object. Fill out those two fields in the generated source metadata
 before committing.
 
+## Refresh Saved Search Totals
+
+After publishing a new data release, refresh the stored result count for each
+user's saved searches:
+
+```bash
+./nde-web/venv/bin/python nde-web/scripts/update_saved_search_totals.py \
+  --metadata-url https://api.data.niaid.nih.gov/v1/metadata
+```
+
+Use `--dry-run` first to count without writing profile updates. When
+`--metadata-url` is provided, the script records the processed `build_version`
+and `build_date` in the user profile index and skips later runs for the same
+build unless `--force` is passed. It also derives the sibling `/v1/query` URL
+from `--metadata-url` and uses that API response to compute frontend-equivalent
+totals, including the frontend's default date range and BioSample visibility
+filter. The script reads Elasticsearch settings from `nde-web/config.py` or
+`nde-web/config_web.py` by default; override them with `--es-host`,
+`--user-index`, or `--data-index` only when needed.
+
 ## Commit Checklist
 
 Commit source-specific metadata outputs:
@@ -95,6 +115,7 @@ nde-web/scripts/bootstrap_source_metadata.py
 nde-web/scripts/metadata_compatibility_calculator.py
 nde-web/scripts/sync_repo_metadata.py
 nde-web/scripts/compute_heuristics.py
+nde-web/scripts/update_saved_search_totals.py
 nde-web/scripts/validate_repo_metadata.py
 nde-web/requirements_scripts.txt
 ```

--- a/nde-web/scripts/update_saved_search_totals.py
+++ b/nde-web/scripts/update_saved_search_totals.py
@@ -1,0 +1,502 @@
+#!/usr/bin/env python3
+"""Refresh stored result totals for user saved searches.
+
+Run this after publishing a new data release so each user profile's
+``favorite_searches[*].total`` reflects the current search index.
+"""
+
+import argparse
+import importlib
+import json
+import logging
+import os
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+from urllib.parse import urlencode, urlsplit, urlunsplit
+from urllib.request import Request, urlopen
+
+
+WEB_DIR = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(WEB_DIR))
+
+from saved_search_counts import (  # noqa: E402
+    DEFAULT_DATA_INDEX,
+    DEFAULT_USER_INDEX,
+    build_saved_search_count_body,
+    build_saved_search_extra_filter,
+)
+
+
+logger = logging.getLogger(__name__)
+
+REFRESH_MARKER_ID = "_saved_search_totals_refresh"
+
+
+def _now_iso():
+    return datetime.now(timezone.utc).replace(microsecond=0).isoformat()
+
+
+def _parse_basic_auth(value):
+    if not value:
+        return None
+    if ":" not in value:
+        raise ValueError("--basic-auth must use USER:PASSWORD format")
+    username, password = value.split(":", 1)
+    return username, password
+
+
+def _load_config_defaults(config_module=None):
+    defaults = {
+        "es_host": None,
+        "user_index": None,
+        "data_index": None,
+        "es_args": {},
+    }
+    module_names = [config_module] if config_module else ["config", "config_web"]
+    for module_name in module_names:
+        if not module_name:
+            continue
+        try:
+            config = importlib.import_module(module_name)
+        except ImportError:
+            continue
+
+        indices = getattr(config, "ES_INDICES", {}) or {}
+        defaults.update(
+            {
+                "es_host": getattr(config, "ES_HOST", None),
+                "user_index": getattr(config, "ES_USER_INDEX", None),
+                "data_index": indices.get(None) or indices.get("dataset"),
+                "es_args": dict(getattr(config, "ES_ARGS", {}) or {}),
+            }
+        )
+        break
+    return defaults
+
+
+def _apply_config_defaults(args):
+    defaults = _load_config_defaults(args.config_module)
+    args.es_host = args.es_host or defaults["es_host"] or "http://localhost:9200"
+    args.user_index = args.user_index or defaults["user_index"] or DEFAULT_USER_INDEX
+    args.data_index = args.data_index or defaults["data_index"] or DEFAULT_DATA_INDEX
+    args.query_url = args.query_url or _query_url_from_metadata_url(args.metadata_url)
+    args.es_args = defaults["es_args"]
+    args.request_timeout = (
+        args.request_timeout
+        or args.es_args.get("request_timeout")
+        or 60
+    )
+    return args
+
+
+def _build_client(args):
+    from elasticsearch import Elasticsearch
+
+    client_kwargs = dict(getattr(args, "es_args", {}) or {})
+    client_kwargs["request_timeout"] = args.request_timeout
+    if args.api_key:
+        client_kwargs["api_key"] = args.api_key
+    if args.basic_auth:
+        client_kwargs["basic_auth"] = _parse_basic_auth(args.basic_auth)
+    if args.ca_certs:
+        client_kwargs["ca_certs"] = args.ca_certs
+    return Elasticsearch(args.es_host, **client_kwargs)
+
+
+def _extract_build_info(metadata):
+    if not isinstance(metadata, dict):
+        return {}
+
+    return {
+        key: metadata[key]
+        for key in ("biothing_type", "build_date", "build_version")
+        if metadata.get(key)
+    }
+
+
+def _fetch_build_info(metadata_url, *, timeout):
+    request = Request(metadata_url, headers={"Accept": "application/json"})
+    with urlopen(request, timeout=timeout) as response:
+        return _extract_build_info(json.load(response))
+
+
+def _query_url_from_metadata_url(metadata_url):
+    if not metadata_url:
+        return None
+
+    parsed = urlsplit(metadata_url)
+    path = parsed.path.rstrip("/")
+    if path.endswith("/metadata"):
+        path = path[: -len("/metadata")] + "/query"
+    else:
+        path = path.rstrip("/") + "/query"
+    return urlunsplit((parsed.scheme, parsed.netloc, path, "", ""))
+
+
+def _resolve_build_info(args):
+    build_info = {}
+    if args.metadata_url:
+        build_info.update(
+            _fetch_build_info(args.metadata_url, timeout=args.request_timeout)
+        )
+    if args.build_date:
+        build_info["build_date"] = args.build_date
+    if args.build_version:
+        build_info["build_version"] = args.build_version
+    return build_info
+
+
+def _is_not_found_error(exc):
+    if getattr(exc, "status_code", None) == 404:
+        return True
+    meta = getattr(exc, "meta", None)
+    if getattr(meta, "status", None) == 404:
+        return True
+    return exc.__class__.__name__ == "NotFoundError"
+
+
+def _get_refresh_marker(client, *, user_index):
+    try:
+        response = client.get(index=user_index, id=REFRESH_MARKER_ID)
+    except Exception as exc:
+        if _is_not_found_error(exc):
+            return None
+        raise
+    return response.get("_source") or {}
+
+
+def _build_marker_matches(marker, build_info):
+    release_keys = {
+        key: value
+        for key, value in build_info.items()
+        if key in {"build_date", "build_version"} and value
+    }
+    if not marker or not release_keys:
+        return False
+    return all(marker.get(key) == value for key, value in release_keys.items())
+
+
+def _save_refresh_marker(client, *, user_index, build_info, stats):
+    body = {
+        "kind": "saved_search_totals_refresh",
+        "updated": _now_iso(),
+        "stats": stats,
+    }
+    body.update(build_info)
+    client.index(index=user_index, id=REFRESH_MARKER_ID, body=body)
+
+
+def _iter_user_profiles(client, *, index, batch_size, scroll):
+    from elasticsearch import helpers
+
+    yield from helpers.scan(
+        client,
+        index=index,
+        query={"query": {"match_all": {}}},
+        size=batch_size,
+        scroll=scroll,
+    )
+
+
+def _count_saved_search(client, *, index, favorite_search):
+    return _count_saved_search_with_es(
+        client,
+        index=index,
+        favorite_search=favorite_search,
+    )
+
+
+def _count_saved_search_with_es(client, *, index, favorite_search):
+    body = build_saved_search_count_body(
+        favorite_search.get("query"),
+        favorite_search.get("filters"),
+    )
+    response = client.count(index=index, query=body["query"])
+    return int(response["count"])
+
+
+def _count_saved_search_with_api(query_url, *, favorite_search, timeout):
+    params = _saved_search_api_params(favorite_search)
+    separator = "&" if urlsplit(query_url).query else "?"
+    request = Request(
+        query_url + separator + urlencode(params),
+        headers={"Accept": "application/json"},
+    )
+    with urlopen(request, timeout=timeout) as response:
+        payload = json.load(response)
+    return _extract_total(payload)
+
+
+def _extract_total(payload):
+    if not isinstance(payload, dict):
+        raise ValueError("Query API response must be a JSON object.")
+    if "total" in payload:
+        return int(payload["total"] or 0)
+
+    total = payload.get("hits", {}).get("total")
+    if isinstance(total, dict):
+        return int(total.get("value") or 0)
+    return int(total or 0)
+
+
+def _saved_search_api_params(favorite_search):
+    params = {
+        "q": favorite_search.get("query") or "__all__",
+        "size": 0,
+        "facet_size": 0,
+        "use_ai_search": "false",
+    }
+
+    extra_filter = build_saved_search_extra_filter(favorite_search.get("filters"))
+    if extra_filter:
+        params["extra_filter"] = extra_filter
+
+    if favorite_search.get("use_ai_search") is not None:
+        params["use_ai_search"] = str(bool(favorite_search["use_ai_search"])).lower()
+
+    return params
+
+
+def refresh_saved_search_totals(
+    client,
+    *,
+    user_index,
+    data_index,
+    batch_size,
+    scroll,
+    query_url=None,
+    request_timeout=60,
+    dry_run=False,
+    limit=None,
+):
+    stats = {
+        "profiles_seen": 0,
+        "profiles_changed": 0,
+        "saved_searches_seen": 0,
+        "saved_searches_changed": 0,
+        "saved_searches_failed": 0,
+    }
+
+    for hit in _iter_user_profiles(
+        client,
+        index=user_index,
+        batch_size=batch_size,
+        scroll=scroll,
+    ):
+        if limit is not None and stats["profiles_seen"] >= limit:
+            break
+
+        doc_id = hit.get("_id")
+        if doc_id == REFRESH_MARKER_ID:
+            continue
+
+        stats["profiles_seen"] += 1
+        source = hit.get("_source") or {}
+        favorite_searches = source.get("favorite_searches") or []
+        if not isinstance(favorite_searches, list):
+            logger.warning(
+                "Skipping profile %s: favorite_searches is not a list",
+                doc_id,
+            )
+            continue
+
+        changed = False
+        for search_index, favorite_search in enumerate(favorite_searches):
+            if not isinstance(favorite_search, dict):
+                logger.warning(
+                    "Skipping profile %s saved search %s: entry is not an object",
+                    doc_id,
+                    search_index,
+                )
+                continue
+
+            stats["saved_searches_seen"] += 1
+            try:
+                if query_url:
+                    total = _count_saved_search_with_api(
+                        query_url,
+                        favorite_search=favorite_search,
+                        timeout=request_timeout,
+                    )
+                else:
+                    total = _count_saved_search(
+                        client,
+                        index=data_index,
+                        favorite_search=favorite_search,
+                    )
+            except Exception:
+                stats["saved_searches_failed"] += 1
+                logger.warning(
+                    "Unable to count profile %s saved search %s",
+                    doc_id,
+                    search_index,
+                    exc_info=True,
+                )
+                continue
+
+            if favorite_search.get("total") != total:
+                favorite_search["total"] = total
+                stats["saved_searches_changed"] += 1
+                changed = True
+
+        if not changed:
+            continue
+
+        stats["profiles_changed"] += 1
+        if dry_run:
+            logger.info("Dry run: would update profile %s", doc_id)
+            continue
+
+        client.update(
+            index=user_index,
+            id=doc_id,
+            body={
+                "doc": {
+                    "favorite_searches": favorite_searches,
+                    "updated": _now_iso(),
+                }
+            },
+        )
+        logger.info("Updated profile %s", doc_id)
+
+    return stats
+
+
+def build_parser():
+    parser = argparse.ArgumentParser(
+        description="Refresh favorite_searches[*].total in user profile data."
+    )
+    parser.add_argument(
+        "--config-module",
+        default=os.getenv("NDE_CONFIG_MODULE"),
+        help="Optional Python config module to read ES defaults from. Defaults to config, then config_web.",
+    )
+    parser.add_argument(
+        "--es-host",
+        default=os.getenv("ELASTICSEARCH_URL") or os.getenv("ES_HOST"),
+        help="Elasticsearch URL. Defaults to env, config.py, then localhost.",
+    )
+    parser.add_argument(
+        "--user-index",
+        default=os.getenv("ES_USER_INDEX"),
+        help=f"User profile index. Defaults to config.py or {DEFAULT_USER_INDEX}.",
+    )
+    parser.add_argument(
+        "--data-index",
+        default=os.getenv("ES_DATA_INDEX"),
+        help=f"Data search index. Defaults to config.py or {DEFAULT_DATA_INDEX}.",
+    )
+    parser.add_argument(
+        "--api-key",
+        default=os.getenv("ELASTICSEARCH_API_KEY") or os.getenv("ES_API_KEY"),
+        help="Optional Elasticsearch API key.",
+    )
+    parser.add_argument(
+        "--basic-auth",
+        default=os.getenv("ELASTICSEARCH_BASIC_AUTH") or os.getenv("ES_BASIC_AUTH"),
+        help="Optional Elasticsearch basic auth in USER:PASSWORD format.",
+    )
+    parser.add_argument(
+        "--ca-certs",
+        default=os.getenv("ELASTICSEARCH_CA_CERTS") or os.getenv("ES_CA_CERTS"),
+        help="Optional CA bundle path.",
+    )
+    parser.add_argument(
+        "--metadata-url",
+        default=os.getenv("NDE_METADATA_URL"),
+        help="Optional /v1/metadata URL used to detect the current build.",
+    )
+    parser.add_argument(
+        "--query-url",
+        default=os.getenv("NDE_QUERY_URL"),
+        help="Optional /v1/query URL used to compute frontend-equivalent totals.",
+    )
+    parser.add_argument(
+        "--build-date",
+        default=os.getenv("NDE_BUILD_DATE"),
+        help="Optional build date override when metadata URL is not available.",
+    )
+    parser.add_argument(
+        "--build-version",
+        default=os.getenv("NDE_BUILD_VERSION"),
+        help="Optional build version override when metadata URL is not available.",
+    )
+    parser.add_argument("--batch-size", type=int, default=500)
+    parser.add_argument("--scroll", default="5m")
+    parser.add_argument("--request-timeout", type=int, default=None)
+    parser.add_argument(
+        "--limit",
+        type=int,
+        default=None,
+        help="Limit profiles processed.",
+    )
+    parser.add_argument("--dry-run", action="store_true", help="Count but do not write.")
+    parser.add_argument(
+        "--force",
+        action="store_true",
+        help="Refresh even if this build was already marked complete.",
+    )
+    parser.add_argument("--verbose", action="store_true")
+    return parser
+
+
+def main(argv=None):
+    args = build_parser().parse_args(argv)
+    args = _apply_config_defaults(args)
+    logging.basicConfig(
+        level=logging.DEBUG if args.verbose else logging.INFO,
+        format="%(levelname)s %(message)s",
+    )
+
+    client = _build_client(args)
+    build_info = _resolve_build_info(args)
+    if build_info:
+        logger.info("Resolved build info: %s", build_info)
+    if args.query_url:
+        logger.info("Counting saved searches with query API: %s", args.query_url)
+    else:
+        logger.warning(
+            "No query API URL configured; falling back to raw Elasticsearch counts."
+        )
+
+    if build_info and not args.force:
+        marker = _get_refresh_marker(client, user_index=args.user_index)
+        if _build_marker_matches(marker, build_info):
+            logger.info(
+                "Saved search totals already refreshed for this build: %s",
+                build_info,
+            )
+            return 0
+
+    stats = refresh_saved_search_totals(
+        client,
+        user_index=args.user_index,
+        data_index=args.data_index,
+        batch_size=args.batch_size,
+        scroll=args.scroll,
+        query_url=args.query_url,
+        request_timeout=args.request_timeout,
+        dry_run=args.dry_run,
+        limit=args.limit,
+    )
+    if build_info and not args.dry_run:
+        if stats["saved_searches_failed"]:
+            logger.warning(
+                "Not marking build complete because %s saved searches failed.",
+                stats["saved_searches_failed"],
+            )
+        else:
+            _save_refresh_marker(
+                client,
+                user_index=args.user_index,
+                build_info=build_info,
+                stats=stats,
+            )
+
+    logger.info("Finished refreshing saved search totals: %s", stats)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/nde-web/user_data.py
+++ b/nde-web/user_data.py
@@ -17,6 +17,7 @@ from datetime import datetime, timezone
 import elasticsearch
 from biothings.web.auth.authn import BioThingsAuthnMixin
 from biothings.web.handlers import BaseAPIHandler
+from saved_search_counts import build_saved_search_count_body
 from tornado.web import HTTPError
 
 logger = logging.getLogger(__name__)
@@ -26,7 +27,7 @@ logger = logging.getLogger(__name__)
 # ---------------------------------------------------------------------------
 
 UPDATABLE_PREFERENCES = frozenset(
-    {"ai_toggle_preference", "contact_preference", "beta"}
+    {"ai_toggle_preference", "contact_preference", "beta", "feedback_preference"}
 )
 
 
@@ -53,6 +54,7 @@ def _seed_user_doc(user: dict) -> dict:
         "favorite_datasets": [],
         "contact_preference": False,
         "beta": False,
+        "feedback_preference": False,
         "created": now,
         "updated": now,
     }
@@ -121,6 +123,15 @@ class _UserDataBase(BioThingsAuthnMixin, BaseAPIHandler):
     def _index(self):
         return self.biothings.config.ES_USER_INDEX
 
+    @property
+    def _data_index(self):
+        indices = getattr(self.biothings.config, "ES_INDICES", {}) or {}
+        return (
+            indices.get(None)
+            or indices.get("dataset")
+            or getattr(self.biothings.config, "ES_INDEX", None)
+        )
+
     async def _get_user_doc(self, doc_id: str) -> dict | None:
         """Fetch a user document; return *None* if it does not exist."""
         try:
@@ -138,6 +149,23 @@ class _UserDataBase(BioThingsAuthnMixin, BaseAPIHandler):
         await self._es.update(
             id=doc_id, body={"doc": partial}, index=self._index
         )
+
+    async def _count_saved_search_total(self, entry: dict) -> int | None:
+        """Return the current result count for a saved search, if available."""
+        index = self._data_index
+        if not index:
+            return None
+
+        body = build_saved_search_count_body(
+            entry.get("query"),
+            entry.get("filters"),
+        )
+        try:
+            resp = await self._es.count(index=index, query=body["query"])
+            return int(resp["count"])
+        except Exception:
+            logger.warning("Unable to count saved search total", exc_info=True)
+            return None
 
 
 # ---------------------------------------------------------------------------
@@ -230,6 +258,7 @@ class UserFavoriteSearchesHandler(_UserDataBase):
             "filters": payload.get("filters", {}),
             "saved_at": _now_iso(),
         }
+        entry["total"] = await self._count_saved_search_total(entry)
 
         doc_id = _user_doc_id(self.current_user)
         doc = await self._get_user_doc(doc_id)

--- a/tests/test_saved_search_counts.py
+++ b/tests/test_saved_search_counts.py
@@ -1,0 +1,106 @@
+import sys
+from pathlib import Path
+
+
+WEB_DIR = Path(__file__).resolve().parents[1] / "nde-web"
+sys.path.insert(0, str(WEB_DIR))
+
+from saved_search_counts import (  # noqa: E402
+    build_saved_search_count_body,
+    build_saved_search_extra_filter,
+    frontend_default_extra_filter,
+)
+
+
+def test_browse_query_uses_match_all_with_type_filter():
+    body = build_saved_search_count_body(
+        "__all__",
+        {},
+        include_frontend_defaults=False,
+    )
+
+    assert body["query"]["bool"]["must"] == [{"match_all": {}}]
+    assert body["query"]["bool"]["filter"][0]["bool"]["minimum_should_match"] == 1
+
+
+def test_simple_query_matches_public_search_shape():
+    body = build_saved_search_count_body(
+        "covid data",
+        {},
+        include_frontend_defaults=False,
+    )
+    queries = body["query"]["bool"]["must"][0]["dis_max"]["queries"]
+
+    assert {"term": {"_id": {"value": "covid data", "boost": 5}}} in queries
+    assert {
+        "query_string": {
+            "query": "covid* data*",
+            "default_operator": "AND",
+            "boost": 0.5,
+            "lenient": True,
+        }
+    } in queries
+
+
+def test_string_filter_is_query_string_clause():
+    body = build_saved_search_count_body(
+        "__all__",
+        '(healthCondition.name:("asthma")) AND -_exists_:measurementTechnique.name',
+        include_frontend_defaults=False,
+    )
+
+    assert body["query"]["bool"]["filter"][1] == {
+        "query_string": {
+            "query": '((healthCondition.name:("asthma")) AND -_exists_:measurementTechnique.name)'
+        }
+    }
+
+
+def test_mapping_filters_become_field_filters():
+    body = build_saved_search_count_body(
+        "covid",
+        {"includedInDataCatalog.name": ["Zenodo", "Figshare"], "@type": "Dataset"},
+        include_frontend_defaults=False,
+    )
+
+    assert body["query"]["bool"]["filter"][1] == {
+        "query_string": {
+            "query": '(includedInDataCatalog.name:("Zenodo" OR "Figshare") AND @type:"Dataset")'
+        }
+    }
+
+
+def test_elasticsearch_query_filter_is_preserved():
+    es_filter = {"range": {"date": {"gte": "2020-01-01", "lte": "2020-12-31"}}}
+    body = build_saved_search_count_body(
+        "__all__",
+        es_filter,
+        include_frontend_defaults=False,
+    )
+
+    assert body["query"]["bool"]["filter"][1] == {
+        "query_string": {"query": '(date:["2020-01-01" TO "2020-12-31"])'}
+    }
+
+
+def test_frontend_default_extra_filter_matches_visible_records():
+    extra_filter = frontend_default_extra_filter(year=2026)
+
+    assert extra_filter == (
+        '(date:["2000-01-01" TO "2026-12-31"] OR (-_exists_:("date"))) '
+        'AND NOT(@type:Sample AND NOT additionalType:"BioSample")'
+    )
+
+
+def test_saved_search_extra_filter_combines_frontend_default_and_user_filters():
+    extra_filter = build_saved_search_extra_filter(
+        {"healthCondition.name": ["asthma", "diabetes"]},
+        year=2026,
+    )
+
+    assert (
+        extra_filter
+        == '((date:["2000-01-01" TO "2026-12-31"] OR (-_exists_:("date"))) '
+        'AND NOT(@type:Sample AND NOT additionalType:"BioSample")) '
+        'AND (healthCondition.name:("asthma" OR "diabetes"))'
+    )

--- a/tests/test_update_saved_search_totals.py
+++ b/tests/test_update_saved_search_totals.py
@@ -1,0 +1,271 @@
+import importlib.util
+import json
+import sys
+import types
+from pathlib import Path
+from urllib.parse import parse_qs, urlsplit
+
+
+SCRIPT_PATH = (
+    Path(__file__).resolve().parents[1]
+    / "nde-web"
+    / "scripts"
+    / "update_saved_search_totals.py"
+)
+
+
+def _load_script_module():
+    spec = importlib.util.spec_from_file_location(
+        "update_saved_search_totals",
+        SCRIPT_PATH,
+    )
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+class FakeClient:
+    def __init__(self, counts):
+        self.counts = list(counts)
+        self.updates = []
+        self.indexes = []
+
+    def count(self, *, index, query):
+        return {"count": self.counts.pop(0)}
+
+    def update(self, *, index, id, body):
+        self.updates.append({"index": index, "id": id, "body": body})
+
+    def index(self, *, index, id, body):
+        self.indexes.append({"index": index, "id": id, "body": body})
+
+
+class FakeUrlopenResponse:
+    def __init__(self, payload):
+        self.payload = payload
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc, tb):
+        return False
+
+    def read(self):
+        return json.dumps(self.payload).encode("utf-8")
+
+
+def test_refresh_saved_search_totals_updates_changed_profile():
+    module = _load_script_module()
+    client = FakeClient([7, 2])
+    hits = [
+        {
+            "_id": "github:alice",
+            "_source": {
+                "favorite_searches": [
+                    {"name": "changed", "query": "covid", "filters": {}, "total": 3},
+                    {"name": "same", "query": "__all__", "filters": {}, "total": 2},
+                ]
+            },
+        }
+    ]
+
+    original_iter = module._iter_user_profiles
+    module._iter_user_profiles = lambda *args, **kwargs: iter(hits)
+    try:
+        stats = module.refresh_saved_search_totals(
+            client,
+            user_index="users",
+            data_index="data",
+            batch_size=500,
+            scroll="5m",
+        )
+    finally:
+        module._iter_user_profiles = original_iter
+
+    assert stats["profiles_seen"] == 1
+    assert stats["profiles_changed"] == 1
+    assert stats["saved_searches_changed"] == 1
+    assert client.updates[0]["index"] == "users"
+    assert client.updates[0]["id"] == "github:alice"
+    assert client.updates[0]["body"]["doc"]["favorite_searches"][0]["total"] == 7
+
+
+def test_refresh_saved_search_totals_can_count_with_query_api():
+    module = _load_script_module()
+    client = FakeClient([])
+    hits = [
+        {
+            "_id": "github:alice",
+            "_source": {
+                "favorite_searches": [
+                    {
+                        "name": "asthma",
+                        "query": "asthma",
+                        "filters": {},
+                        "total": 99999,
+                    },
+                ]
+            },
+        }
+    ]
+
+    opened_urls = []
+
+    def fake_urlopen(request, timeout):
+        opened_urls.append(request.full_url)
+        return FakeUrlopenResponse({"total": 11500})
+
+    original_iter = module._iter_user_profiles
+    original_urlopen = module.urlopen
+    module._iter_user_profiles = lambda *args, **kwargs: iter(hits)
+    module.urlopen = fake_urlopen
+    try:
+        stats = module.refresh_saved_search_totals(
+            client,
+            user_index="users",
+            data_index="data",
+            batch_size=500,
+            scroll="5m",
+            query_url="https://api-staging.data.niaid.nih.gov/v1/query",
+        )
+    finally:
+        module._iter_user_profiles = original_iter
+        module.urlopen = original_urlopen
+
+    assert stats["saved_searches_changed"] == 1
+    assert client.updates[0]["body"]["doc"]["favorite_searches"][0]["total"] == 11500
+    assert len(opened_urls) == 1
+    parsed = urlsplit(opened_urls[0])
+    params = parse_qs(parsed.query)
+    assert parsed.geturl().startswith("https://api-staging.data.niaid.nih.gov/v1/query?")
+    assert params["q"] == ["asthma"]
+    assert params["size"] == ["0"]
+    assert params["facet_size"] == ["0"]
+    assert params["use_ai_search"] == ["false"]
+    assert "NOT(@type:Sample AND NOT additionalType:\"BioSample\")" in (
+        params["extra_filter"][0]
+    )
+
+
+def test_extract_build_info_reads_metadata_release_fields():
+    module = _load_script_module()
+
+    build_info = module._extract_build_info(
+        {
+            "biothing_type": "dataset",
+            "build_date": "2026-06-15T23:16:49.294558-07:00",
+            "build_version": "20260615",
+            "src": {},
+        }
+    )
+
+    assert build_info == {
+        "biothing_type": "dataset",
+        "build_date": "2026-06-15T23:16:49.294558-07:00",
+        "build_version": "20260615",
+    }
+
+
+def test_query_url_is_derived_from_metadata_url():
+    module = _load_script_module()
+
+    assert (
+        module._query_url_from_metadata_url(
+            "https://api-staging.data.niaid.nih.gov/v1/metadata"
+        )
+        == "https://api-staging.data.niaid.nih.gov/v1/query"
+    )
+
+
+def test_saved_search_api_params_convert_filters_to_extra_filter():
+    module = _load_script_module()
+
+    params = module._saved_search_api_params(
+        {
+            "query": "__all__",
+            "filters": {
+                "healthCondition.name": ["asthma", "diabetes"],
+                "@type": "Dataset",
+            },
+        }
+    )
+
+    assert params["q"] == "__all__"
+    assert params["size"] == 0
+    assert params["facet_size"] == 0
+    assert params["use_ai_search"] == "false"
+    assert 'date:["2000-01-01" TO "' in params["extra_filter"]
+    assert 'AND NOT(@type:Sample AND NOT additionalType:"BioSample")' in (
+        params["extra_filter"]
+    )
+    assert 'healthCondition.name:("asthma" OR "diabetes")' in (
+        params["extra_filter"]
+    )
+    assert '@type:"Dataset"' in params["extra_filter"]
+
+
+def test_build_marker_matches_current_build_version():
+    module = _load_script_module()
+
+    assert module._build_marker_matches(
+        {"build_version": "20260615", "build_date": "old"},
+        {"build_version": "20260615"},
+    )
+    assert not module._build_marker_matches(
+        {"build_version": "20260614"},
+        {"build_version": "20260615"},
+    )
+
+
+def test_save_refresh_marker_records_build_info_and_stats():
+    module = _load_script_module()
+    client = FakeClient([])
+
+    module._save_refresh_marker(
+        client,
+        user_index="users",
+        build_info={"build_version": "20260615"},
+        stats={"profiles_seen": 2},
+    )
+
+    assert client.indexes[0]["index"] == "users"
+    assert client.indexes[0]["id"] == module.REFRESH_MARKER_ID
+    assert client.indexes[0]["body"]["kind"] == "saved_search_totals_refresh"
+    assert client.indexes[0]["body"]["build_version"] == "20260615"
+    assert client.indexes[0]["body"]["stats"] == {"profiles_seen": 2}
+
+
+def test_apply_config_defaults_reads_es_settings_from_config_module():
+    module = _load_script_module()
+    config_name = "fake_nde_config_for_saved_search_totals"
+    config = types.ModuleType(config_name)
+    config.ES_HOST = "http://172.30.2.11:9200"
+    config.ES_USER_INDEX = "custom_user_profiles"
+    config.ES_INDICES = {None: "custom_data_current"}
+    config.ES_ARGS = {
+        "request_timeout": 120,
+        "max_retries": 5,
+        "http_compress": True,
+    }
+    sys.modules[config_name] = config
+
+    args = types.SimpleNamespace(
+        config_module=config_name,
+        es_host=None,
+        user_index=None,
+        data_index=None,
+        metadata_url=None,
+        query_url=None,
+        request_timeout=None,
+    )
+    try:
+        args = module._apply_config_defaults(args)
+    finally:
+        sys.modules.pop(config_name, None)
+
+    assert args.es_host == "http://172.30.2.11:9200"
+    assert args.user_index == "custom_user_profiles"
+    assert args.data_index == "custom_data_current"
+    assert args.request_timeout == 120
+    assert args.es_args["max_retries"] == 5
+    assert args.es_args["http_compress"] is True

--- a/tests/test_user_account_config.py
+++ b/tests/test_user_account_config.py
@@ -1,0 +1,25 @@
+import ast
+from pathlib import Path
+
+
+CONFIG_WEB = Path(__file__).resolve().parents[1] / "nde-web" / "config_web.py"
+
+
+def _string_literals(node):
+    for child in ast.walk(node):
+        if isinstance(child, ast.Constant) and isinstance(child.value, str):
+            yield child.value
+
+
+def test_user_account_routes_are_registered():
+    tree = ast.parse(CONFIG_WEB.read_text())
+    strings = set(_string_literals(tree))
+
+    assert "nde_user_profiles" in strings
+    assert "/user_info" in strings
+    assert "/login/github" in strings
+    assert "/login/orcid" in strings
+    assert "/xsrf_token" in strings
+    assert "/user/data" in strings
+    assert "/user/data/favorites/searches" in strings
+    assert "/user/data/favorites/datasets" in strings


### PR DESCRIPTION
This pull request promotes the backend pieces needed for the user account and saved content feature. It registers the production routes for login/profile access, enables saved searches and datasets to be persisted to user profile documents, and adds support for keeping saved-search result totals aligned with the current search index.

**User Account and Saved Content Routing:**

* Updated `config_web.py` to register OAuth, logout, user info, XSRF, and user-data endpoints, and to configure the `UserCookieAuthProvider` authentication chain.
* Added `ES_USER_INDEX` configuration for persistent user profile documents.
* Registered endpoints for saved searches and saved datasets under `/user/data/favorites/...`.

**Saved Search Totals:**

* Added `saved_search_counts.py` to build Elasticsearch count queries for saved searches using frontend-equivalent defaults.
* Updated saved-search persistence to store a current `total` value when a search is saved.
* Added `update_saved_search_totals.py` and documentation for refreshing saved-search totals after new data releases.

**Tests:**

* Added focused tests for saved-search count query generation, refresh script behavior, and production route wiring.
* Verified locally with:

```bash
pytest -q tests/test_saved_search_counts.py tests/test_update_saved_search_totals.py tests/test_user_account_config.py
```
